### PR TITLE
Fix typo in audit.conf to auditd.conf for EL 7 targets

### DIFF
--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -132,7 +132,7 @@
     - V-38637
 
 - name: Check audit package contents for alterations with rpm (for V-38637)
-  shell: rpmverify audit audit-libs | grep -v audit.conf | wc -l
+  shell: rpmverify audit audit-libs | grep -v auditd.conf | wc -l
   register: v38637_result
   when: ansible_pkg_mgr == 'yum'
   tags:


### PR DESCRIPTION
auditd.conf changes must not be counted in check V-38637 but it was incorrectly implemented as "audit.conf"
