### PR TITLE
Fix ansible_os_family loops to look for Debian

### DIFF
--- a/tasks/rhel7stig/aide.yml
+++ b/tasks/rhel7stig/aide.yml
@@ -93,7 +93,7 @@
     marker: "# {mark} MANAGED BY OPENSTACK-ANSIBLE-SECURITY"
     block: "{{ lookup('file', 'aide_extra.conf') }}"
   when:
-    - ansible_os_family | lower == 'ubuntu'
+    - ansible_os_family | lower == 'debian'
   tags:
     - low
     - aide

--- a/tasks/rhel7stig/packages.yml
+++ b/tasks/rhel7stig/packages.yml
@@ -82,7 +82,7 @@
     src: 20auto-upgrades
     dest: /etc/apt/apt.conf.d/20auto-upgrades
   when:
-    - ansible_os_family | lower == 'ubuntu'
+    - ansible_os_family | lower == 'debian'
     - security_rhel7_automatic_package_updates | bool
   tags:
     - packages


### PR DESCRIPTION
Two when loops were looking for Ubuntu, rather than Debian, as
ansible_os_family, which caused those plays to fail when run against
Ubuntu machines.