### PR TITLE
Use jinja 2.8+ syntax for greater than test to avoid error and fail

### DIFF
--- a/tasks/rhel7stig/file_perms.yml
+++ b/tasks/rhel7stig/file_perms.yml
@@ -107,7 +107,7 @@
   when:
     - item.uid >= 1000
     - security_set_home_directory_permissions_and_owners | bool
-  with_items: "{{ user_list.users | selectattr('uid', 'greater_than', 999) | list }}"
+  with_items: "{{ user_list.users | selectattr('uid', 'greaterthan', 999) | list }}"
   tags:
     - medium
     - file_perms


### PR DESCRIPTION
Jinja 2.8+ uses "greaterthan" not "greater_than".  Test fails on Ubuntu 16.04, jinja 2.9.5
http://jinja.pocoo.org/docs/dev/templates/#list-of-builtin-tests