### PR TITLE
Minor changes

### DIFF
--- a/tasks/rhel7stig/auditd.yml
+++ b/tasks/rhel7stig/auditd.yml
@@ -180,6 +180,7 @@
     enabled: yes
   when:
     - auditd_conf.stat.exists
+    - security_enable_audit_during_boot | bool
   tags:
     - high
     - auditd

--- a/tasks/rhel7stig/auth.yml
+++ b/tasks/rhel7stig/auth.yml
@@ -527,7 +527,7 @@
   file:
     path: "{{ item.path }}"
     state: absent
-  with_items: "{{ shosts_find.files }}"
+  with_items: "{{ shosts_find.files | default([]) }}"
   when:
     - security_rhel7_remove_shosts_files | bool
     - shosts_find is defined

--- a/tasks/rhel7stig/sshd.yml
+++ b/tasks/rhel7stig/sshd.yml
@@ -85,23 +85,39 @@
     - sshd
     - RHEL-07-040261
 
+- name: Search for public host key files
+  command: find /etc/ssh/ -type f -name \*.pub
+  args:
+    warn: no
+  register: public_host_key_files
+  changed_when: false
+  tags:
+    - sshd
+
 - name: Public host key files must have mode 0644 or less
   file:
     path: "{{ item }}"
     mode: "u-xX,g-wxs,o-wxt"
-  with_fileglob:
-    - /etc/ssh/*.pub
+  with_items: "{{ public_host_key_files.stdout_lines }}"
   tags:
     - medium
     - sshd
     - RHEL-07-040640
 
+- name: Search for private host key files
+  command: find /etc/ssh/ -type f -name \*_key
+  args:
+    warn: no
+  register: private_host_key_files
+  changed_when: false
+  tags:
+    - sshd
+
 - name: Private host key files must have mode 0600 or less
   file:
     path: "{{ item }}"
     mode: "u-xX,g-rwxs,o-rwxt"
-  with_fileglob:
-    - /etc/ssh/*_key
+  with_items: "{{ private_host_key_files.stdout_lines }}"
   tags:
     - medium
     - sshd


### PR DESCRIPTION
1) When running ansible on OS X, the with_fileglob /etc/ssh/*.pub was failing:
```
 failed: [<redacted>] (item=/private/etc/ssh/ssh_host_dsa_key.pub) => {"failed": true, "item": "/private/etc/ssh/ssh_host_dsa_key.pub", "msg": "file (/private/etc/ssh/ssh_host_dsa_key.pub) is absent, cannot continue", "path": "/private/etc/ssh/ssh_host_dsa_key.pub", "state": "absent"}
```

2) I added security_enable_audit_during_boot to allow disabling the auditd.service startup as the VPS I am currently using does not allow the service to run

3) dict object issues with empty list, other tasks included the same change:
example: ```openstack-ansible-security/tasks/rhel7stig/rpm.yml:  with_items: "{{ rpm_gpgchecks | default([]) }}"```