### PR TITLE
Logic fails for 'security_sshd_permit_root_login'

### DIFF
--- a/templates/sshd_config_block.j2
+++ b/templates/sshd_config_block.j2
@@ -22,7 +22,7 @@ ClientAliveCountMax {{ security_sshd_client_alive_count_max }}
 # V-72245
 PrintLastLog yes
 {% endif %}
-{% if security_sshd_permit_root_login | bool %}
+{% if not security_sshd_permit_root_login | bool %}
 # V-72247
 PermitRootLogin no
 {% endif %}


### PR DESCRIPTION
From defaults/main.yml

```
# Permit direct root logins
security_sshd_permit_root_login: no                          # V-72247
```
That makes sense as a setting/configuration since that echoes what you'd expect to set in sshd_config yourself. However, when this is handled in tasks/rhel7stig/sshd.yml and ultimately templates/sshd_config_block.j2 this doesn't work as expected.

The part in sshd_config_block.j2 than references this is:

```
{% if security_sshd_permit_root_login | bool %}
# V-72247
PermitRootLogin no
{% endif %}

```

Basically - if the variable is set to no, the line below fails the boolean test and is not written into the sshd_config file. I believe that anyone who runs this against their hosts with this setting will still be allowing root logins although they think they're not. 

If you set the variable to yes, it just 'feels and looks' wrong to me.

I'm not good enough at Ansible and Jinja2 to figure out how to do a 'negative' bool after the | so I put in the following instead:

`{% if not security_sshd_permit_root_login | bool %}`

Maybe there's a more elegant solution to this?

This is the first instance of this issue I've spotted but there might be more - I'll try and go through the ssh settings closer now.

Cheers, Mike