### PR TITLE
Fix security_enable_chrony: no not work issue

### DIFF
--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -48,12 +48,15 @@ stig_packages:
       - audispd-plugins
       - aide
       - aide-common
-      - chrony
       - debsums
       - logrotate
       - postfix
     state: "{{ security_package_state }}"
     enabled: True
+  - packages:
+      - chrony
+    state: "{{ security_package_state }}"
+    enabled: "{{ security_enable_chrony }}"
   - packages:
       - apparmor
       - apparmor-profiles


### PR DESCRIPTION
Crony package is installed no matter security_enable_chrony is yes or
no, which will remove ntp package automatically.